### PR TITLE
setup.py decode utf-8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: false
 
 env:
   - TEST_TARGET=unit PYTHON_TARGET=2.7
-  - TEST_TARGET=unit PYTHON_TARGET=3.4
+  - TEST_TARGET=unit PYTHON_TARGET=3.6
   # - TEST_TARGET=integration
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: c
+language: python
 sudo: false
 
 #python:

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ else:
                     "netcdf4>=1.0",
                     "numpy",
                     "scipy>=0.15.0",
-                    "iris>=1.8.0",
-                    'psutil>=2.0.0',
-                    'six']
+                    "scitools-iris>=1.8.0",
+                    "psutil>=2.0.0",
+                    "six"]
 
     optional_dependencies = {"HDF": ["pyhdf"], "Pandas": ["pandas"]}
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if on_rtd:
     test_dependencies = []
 
 else:
-    dependencies = ["matplotlib>=1.2.0",
+    dependencies = ["matplotlib>=1.2.0,<1.9.0",
                     "netcdf4>=1.0",
                     "numpy",
                     "scipy>=0.15.0",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ class check_dep(Command):
                 print(dep + "... MISSING!")
 
 # Extract long-description from README
-README = open(os.path.join(root_path, 'README.md')).read()
+README = open(os.path.join(root_path, 'README.md'), 'rb').read().decode('utf-8')
 
 setup(
     name='cis',


### PR DESCRIPTION
@duncanwp This fix resolves the following issue that I was encountering whilst trying to build `cis` for `python 3.6`:

```python
    README = open(os.path.join(root_path, 'README.md')).read()
  File "/home/conda_builder/conda-bld/cis_1525100351208/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1321: ordinal not in range(128)
```